### PR TITLE
Juju status key error

### DIFF
--- a/collect-logs
+++ b/collect-logs
@@ -54,6 +54,7 @@ DEFAULT_MODEL = object()
 VERBOSE = False
 
 JujuUnit = namedtuple("JujuUnit", ["name", "ip"])
+NO_PUBLIC_ADDRESS = "No public-address found"
 
 if VERBOSE:
     def call(args, env=None, _call=call):
@@ -159,14 +160,14 @@ class Juju(object):
 
     def ssh_args(self, unit, cmd):
         """Return the subprocess.* args for an SSH command."""
-        if self.juju_ssh:
+        if self.juju_ssh or unit.ip == NO_PUBLIC_ADDRESS:
             return self._resolve("ssh", unit.name, cmd)
         direct_ssh_args = self._direct_ssh_args("ssh")
         return direct_ssh_args + ["ubuntu@{}".format(unit.ip), cmd]
 
     def pull_args(self, unit, source, target="."):
         """Return the subprocess.* args for an SCP command."""
-        if self.juju_ssh:
+        if self.juju_ssh or unit.ip == NO_PUBLIC_ADDRESS:
             source = "{}:{}".format(unit.name, source)
             return self._resolve("scp", source, target)
         source = "ubuntu@{}:{}".format(unit.ip, source)
@@ -174,7 +175,7 @@ class Juju(object):
 
     def push_args(self, unit, source, target):
         """Return the subprocess.* args for an SCP command."""
-        if self.juju_ssh:
+        if self.juju_ssh or unit.ip == NO_PUBLIC_ADDRESS:
             target = "{}:{}".format(unit.name, target)
             return self._resolve("scp", source, target)
         target = "ubuntu@{}:{}".format(unit.ip, target)
@@ -261,7 +262,13 @@ def get_units(juju, status=None):
             continue
         if "units" in applications[application]:
             for name, unit in applications[application]["units"].items():
-                juju_units.append(JujuUnit(name, unit["public-address"]))
+                if not unit.get("public-address"):
+                    log.warning( 
+                        "Couldn't obtain public-address for unit {}".format(
+                            unit.name))
+                    juju_units.append(JujuUnit(name, NO_PUBLIC_ADDRESS))
+                else:
+                    juju_units.append(JujuUnit(name, unit["public-address"]))
     if len(juju_units) == 0:
         sys.exit("ERROR, no units found. Make sure the right juju environment"
                  "is set.")

--- a/collect-logs
+++ b/collect-logs
@@ -269,7 +269,7 @@ def get_units(juju, status=None):
                 if not unit.get("public-address"):
                     log.warning( 
                         "Couldn't obtain public-address for unit {}".format(
-                            unit.name))
+                            name))
                     juju_units.append(JujuUnit(name, NO_PUBLIC_ADDRESS))
                 else:
                     juju_units.append(JujuUnit(name, unit["public-address"]))

--- a/collect-logs
+++ b/collect-logs
@@ -54,6 +54,10 @@ DEFAULT_MODEL = object()
 VERBOSE = False
 
 JujuUnit = namedtuple("JujuUnit", ["name", "ip"])
+
+# This contant is a marker to indicate that public-address wasn't found for a
+# JujuUnit. In these cases, 'juju ssh <unit_name>' will be used instead of
+# 'ssh ubuntu@<unit_ip>'
 NO_PUBLIC_ADDRESS = "No public-address found"
 
 if VERBOSE:

--- a/test_collect-logs.py
+++ b/test_collect-logs.py
@@ -134,6 +134,19 @@ class GetJujuTests(TestWithFixtures):
         unit = script.JujuUnit("ubuntu/0", "10.1.1.1")
         self.assertEqual(expected, juju.ssh_args(unit,"ls tmp"))
 
+    def test_get_args_without_ssh_missing_public_address_uses_juju_ssh(self):
+        """
+        When juju_ssh is False, but juju status doesn't report public-address
+        for a unit, ssh_args falls back to using 'juju ssh'.
+        """
+        self.useFixture(
+            EnvironmentVariableFixture("JUJU_DATA", "some-dir"))
+        juju = script.get_juju(script.JUJU2, inner=False, juju_ssh=False)
+        expected = ["juju-2.1", "ssh", "ubuntu/0", "ls tmp"]
+        self.assertFalse(juju.juju_ssh)
+        unit = script.JujuUnit("ubuntu/0", script.NO_PUBLIC_ADDRESS)
+        self.assertEqual(expected, juju.ssh_args(unit,"ls tmp"))
+
     def test_pull_args_without_ssh_uses_ip_address(self):
         """
         When juju_ssh is False, get_juju returns direct ssh commands from
@@ -149,6 +162,18 @@ class GetJujuTests(TestWithFixtures):
         unit = script.JujuUnit("ubuntu/0", "10.1.1.1")
         self.assertEqual(expected, juju.pull_args(unit, "file1"))
 
+    def test_pull_args_without_ssh_missing_public_address_uses_juju_ssh(self):
+        """
+        When juju_ssh is False, but juju status doesn't report public-address
+        for a unit, Juju.pull_args falls back to using 'juju ssh'.
+        """
+        self.useFixture(
+            EnvironmentVariableFixture("JUJU_DATA", "some-dir"))
+        juju = script.get_juju(script.JUJU2, inner=False, juju_ssh=False)
+        expected = ["juju-2.1", "scp", "ubuntu/0:file1", "."]
+        unit = script.JujuUnit("ubuntu/0", script.NO_PUBLIC_ADDRESS)
+        self.assertEqual(expected, juju.pull_args(unit, "file1"))
+
     def test_push_args_without_ssh_uses_ip_address(self):
         """
         When juju_ssh is False, get_juju returns direct ssh commands from
@@ -162,6 +187,18 @@ class GetJujuTests(TestWithFixtures):
             "-i", "some-dir/ssh/juju_id_rsa",
             "file1", "ubuntu@10.1.1.1:/tmp/blah"]
         unit = script.JujuUnit("ubuntu/0", "10.1.1.1")
+        self.assertEqual(expected, juju.push_args(unit, "file1", "/tmp/blah"))
+
+    def test_push_args_without_ssh_missing_public_address_uses_juju_ssh(self):
+        """
+        When juju_ssh is False, but juju status doesn't report public-address
+        for a unit, Juju.push_args falls back to using 'juju ssh'.
+        """
+        self.useFixture(
+            EnvironmentVariableFixture("JUJU_DATA", "some-dir"))
+        juju = script.get_juju(script.JUJU2, inner=False, juju_ssh=False)
+        expected = ["juju-2.1", "scp", "file1", "ubuntu/0:/tmp/blah"]
+        unit = script.JujuUnit("ubuntu/0", script.NO_PUBLIC_ADDRESS)
         self.assertEqual(expected, juju.push_args(unit, "file1", "/tmp/blah"))
 
     def test_juju2_inner(self):


### PR DESCRIPTION
Log warnings when juju status output doesn't provide a public-address for certain juju units.

This branch marks suck units with NO_PUBLIC_ADDRESS so Juju.ssh_args, Juju.pull_args and Juju.push_args can fall back to trying  "juju ssh <unit_name>" instead of "ssh ubuntu@<unit_ip>" .

This addresses Issue #6 